### PR TITLE
Feature: add disable gap config option

### DIFF
--- a/common/src/main/java/net/mandalacreations/clean_tooltips/client/TooltipSection.java
+++ b/common/src/main/java/net/mandalacreations/clean_tooltips/client/TooltipSection.java
@@ -1,6 +1,6 @@
 package net.mandalacreations.clean_tooltips.client;
 
-
+import net.mandalacreations.clean_tooltips.client.config.ClientConfig;
 import net.minecraft.network.chat.Component;
 import net.neoforged.neoforge.common.ModConfigSpec;
 import org.jetbrains.annotations.Nullable;
@@ -23,7 +23,7 @@ public abstract class TooltipSection {
 
     public void create() {
         if (this.enabled.get() && this.shouldDisplay()) {
-            if (!this.isFirstSection()) {
+            if (ClientConfig.INSTANCE.gapEnabled().get() && !this.isFirstSection()) {
                 this.addComponent(Component.empty());
             }
 
@@ -59,7 +59,7 @@ public abstract class TooltipSection {
     }
 
     protected boolean isFirstSection() {
-        //TODO
+        // TODO
         return false;
     }
 

--- a/common/src/main/java/net/mandalacreations/clean_tooltips/client/config/ClientConfig.java
+++ b/common/src/main/java/net/mandalacreations/clean_tooltips/client/config/ClientConfig.java
@@ -14,7 +14,8 @@ public record ClientConfig(ModConfigSpec.BooleanValue durabilitySectionEnabled,
                            ModConfigSpec.EnumValue<ChatFormatting> curseEnchantmentColor,
                            ModConfigSpec.EnumValue<ChatFormatting> normalEnchantmentColor,
                            ModConfigSpec.EnumValue<ChatFormatting> maxLevelEnchantmentColor,
-                           ModConfigSpec.BooleanValue colorSectionEnabled) {
+                           ModConfigSpec.BooleanValue colorSectionEnabled,
+                           ModConfigSpec.BooleanValue gapEnabled) {
 
     public static final IConfigSpec SPEC;
     public static final ClientConfig INSTANCE;
@@ -32,7 +33,8 @@ public record ClientConfig(ModConfigSpec.BooleanValue durabilitySectionEnabled,
                 build.comment("The color curses should have").defineEnum("enchantments.color.curse", ChatFormatting.RED),
                 build.comment("The color normal enchantments should have").defineEnum("enchantments.color.normal", ChatFormatting.GREEN),
                 build.comment("The color max level enchantments should have").defineEnum("enchantments.color.max_level", ChatFormatting.GOLD),
-                build.comment("Should the fancied up Color section be used?").define("color.enabled", true)
+                build.comment("Should the fancied up Color section be used?").define("color.enabled", true),
+                build.comment("Should sections of the tooltip have spacing between them?").define("gap.enabled", true)
         );
     }
 }


### PR DESCRIPTION
The gaps between the tooltip sections feel like a bit too much for me, mostly when using together with legendary tooltips.
I don't know if there's a way to make the actual gap size configurable, so i figured a basic setting to turn the gaps off wouldn't hurt, at least for people who prefer a more compact look.

### Gap on (default look):
![Screenshot_1](https://github.com/user-attachments/assets/0f104383-9a76-4e7a-ba9d-b93c608198de)
![Screenshot_4](https://github.com/user-attachments/assets/cbd92ee1-19f6-412d-aa60-85b5a61c2aff)

### Gap off:
![Screenshot_3](https://github.com/user-attachments/assets/539f85f0-cd35-480b-b040-a1b18b59d015)
![Screenshot_2](https://github.com/user-attachments/assets/9ed9e369-fbcf-45a5-9949-19027b1942d6)
